### PR TITLE
Bump crewai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.115.8
 uvicorn==0.34.0
 python-dotenv==1.0.1
-crewai==0.10.0
+crewai==0.102.0
 masumi_crewai


### PR DESCRIPTION
Fixes "TypeError: Crew.kickoff() takes 1 positional argument but 2 were given" when running the agent